### PR TITLE
WIKI-582: Wrong action icons for Template management in non-English languages

### DIFF
--- a/wiki-webapp/src/main/webapp/skin/less/wiki.less
+++ b/wiki-webapp/src/main/webapp/skin/less/wiki.less
@@ -360,6 +360,14 @@
 	padding: 8px 15px 15px;
 }
 
+.uiIconEditTemplate{
+  background-position: -40px 0px;
+}
+
+.uiIconDeleteTemplate{
+  background-position: -20px 0px;
+}
+
 /******* wiki space-switcher ************/
 
 .uiWikiPortlet {

--- a/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiGrid.gtmpl
+++ b/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiGrid.gtmpl
@@ -197,7 +197,6 @@
                      def beanId = uicomponent.getBeanIdFor(bean);
                      for (action in beanActions) {
                        String title = _ctx.appRes(uiParent.getName() + ".action.title." + action);
-                       String actionName = action.replace("Template",""); 
                        String actionLink = "";
                        if (uiForm != null) {
                          actionLink = uiForm.event(action, uiParent.getId(), beanId);
@@ -208,10 +207,10 @@
                        String anchor = "#" + action;
                        if (Utils.getModeFromAction(action)) {
                  %>
-                         <a onclick="eXo.wiki.UIWikiAjaxRequest.makeNewHash('$anchor/$beanId');" alt="$action" class="actionIcon"  rel="tooltip" data-placement="bottom" title="$title"><i class="uiIcon$actionName"></i></a>
+                         <a onclick="eXo.wiki.UIWikiAjaxRequest.makeNewHash('$anchor/$beanId');" alt="$action" class="actionIcon"  rel="tooltip" data-placement="bottom" title="$title"><i class="uiIcon$action"></i></a>
                          <a onclick="$actionLink" id="$actionId/$beanId" style="display:none;">&nbsp;</a>
                  <%    } else { %>
-                         <a onclick="$actionLink" alt="$action" class="actionIcon"  rel="tooltip" data-placement="bottom" title="$title"><i class="uiIcon$actionName"></i></a>
+                         <a onclick="$actionLink" alt="$action" class="actionIcon"  rel="tooltip" data-placement="bottom" title="$title"><i class="uiIcon$action"></i></a>
                  <%    } %>
                    <%} %>                 
                </td>


### PR DESCRIPTION
Fix description:
- Get the action name from resource key instead of from its translation
