### PR TITLE
WIKI-600 Invalid percent escape for page with national name

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -1,6 +1,5 @@
 package org.exoplatform.wiki.utils;
 
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -219,7 +218,7 @@ public class Utils {
     }
     
     if (params.getPageId() != null) {
-      sb.append(URLEncoder.encode(params.getPageId(), "UTF-8"));
+      sb.append(params.getPageId());
     }
     
     if (hasDowmainUrl) {

--- a/wiki-webapp/src/main/java/org/exoplatform/wiki/commons/Utils.java
+++ b/wiki-webapp/src/main/java/org/exoplatform/wiki/commons/Utils.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.wiki.commons;
 
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -376,6 +377,10 @@ public class Utils {
   public static void redirect(WikiPageParams pageParams, WikiMode mode, Map<String, String[]> params) throws Exception {
     PortalRequestContext portalRequestContext = Util.getPortalRequestContext();
     portalRequestContext.setResponseComplete(true);
+    if (PortalConfig.GROUP_TYPE.equals(Utils.getCurrentWiki().getType())) {
+      pageParams.setPageId(URLEncoder.encode(pageParams.getPageId(), "UTF-8"));
+    }
+    
     portalRequestContext.sendRedirect(createURLWithMode(pageParams, mode, params));
   }
   

--- a/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiMyDraftsForm.java
+++ b/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiMyDraftsForm.java
@@ -91,6 +91,13 @@ public class UIWikiMyDraftsForm extends UIForm {
         if (pageImpl == null) {
           continue;
         }
+        
+        // Check if target page was deleted
+        if (pageImpl.getWiki() == null) {
+          draftPage.remove();
+          continue;
+        }
+        
         List<BreadcrumbData> breadcrumbDatas = wService.getBreadcumb(pageImpl.getWiki().getType(), pageImpl.getWiki().getOwner(), pageImpl.getName());
         grid.putBreadCrumbDatas(draftPage.getName(), breadcrumbDatas);
         String draftTitle = draftPage.getTitle();

--- a/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiPortlet.java
+++ b/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiPortlet.java
@@ -181,8 +181,11 @@ public class UIWikiPortlet extends UIPortletApplication {
                                                                                              .setValue(page.getTitle());      
       } catch (Exception e) {
         context.setAttribute("wikiPage", null);
-        UIWikiContentDisplay contentDisplay = findFirstComponentOfType(UIWikiPageContentArea.class).getChildById(UIWikiPageContentArea.VIEW_DISPLAY);
-        contentDisplay.setHtmlOutput(("Exceptions occur when rendering content!"));
+        UIWikiPageContentArea wikiPageContentArea = findFirstComponentOfType(UIWikiPageContentArea.class);
+        if (wikiPageContentArea != null) {
+          UIWikiContentDisplay contentDisplay = wikiPageContentArea.getChildById(UIWikiPageContentArea.VIEW_DISPLAY);
+          contentDisplay.setHtmlOutput(("Exceptions occur when rendering content!"));
+        }
         if (log.isWarnEnabled()) {
           log.warn("An exception happens when resolving URL: " + requestURL, e);
         }


### PR DESCRIPTION
Problem Analysis:
- PortalRequestContext.sendRedirect is using charset iso-8859-1 to encode URL.This encoding causes the webserver not understand url properly when the url containing special characters such as é, à, ç in French, or Vietnamese characters, or Japanese ones
- When going draft page list, if target page of draft page was deleted, then exception happens due to parent of target page not found
  Solution:
- Encoding property pageid before redirecting
- if target page not found, remove it
