### PR TITLE
WIKI-597: Exception when renaming a page like the title of a removed one

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -1232,7 +1232,7 @@ public class WikiServiceImpl implements WikiService, Startable {
     LinkEntry checkEntry = newEntry;
     while (!checkEntry.equals(entry) && circularFlag > 0) {
       checkEntry = checkEntry.getNewLink();
-      if (checkEntry.getNewLink().equals(checkEntry) && !checkEntry.equals(entry)) {
+      if (checkEntry == null || (checkEntry.equals(checkEntry.getNewLink()) && !checkEntry.equals(entry))) {
         isCircular = false;
         break;
       }


### PR DESCRIPTION
Fix description:

Caused by: *\* NullPointerException on processCircularRename function when getNewLink() from checkEntry.(checkEntry == newEntry) *\* Because of newEntry.getNewLink() has been set to null when deletePage.
How to fixed? *\* Remove setting NewLink in deletePage function
