### PR TITLE
Fix/4.0.x/wiki 586

### DIFF
--- a/wiki-webapp/src/main/webapp/templates/wiki/webui/popup/UIWikiPagePreview.gtmpl
+++ b/wiki-webapp/src/main/webapp/templates/wiki/webui/popup/UIWikiPagePreview.gtmpl
@@ -1,4 +1,5 @@
 <% 
+  import org.apache.commons.lang.StringEscapeUtils;
   def rcontext = _ctx.getRequestContext();
   def requireJs = rcontext.getJavascriptManager().getRequireJS();
   requireJs.require("SHARED/WikiLayout", "WikiLayout");  
@@ -7,7 +8,7 @@
 
 <div class="uiWikiPagePreview">
   <div class="uiWikiPageTitlePreview">
-    ${uicomponent.pageTitle}
+    <%=StringEscapeUtils.escapeHtml(uicomponent.pageTitle)%>
   </div>
   <% uicomponent.renderChildren(); %>
 </div>


### PR DESCRIPTION
Link issue: https://jira.exoplatform.org/browse/WIKI-586
Fix description: Escape html for the title of page before display page preview