### PR TITLE
Fix/4.0.x/wiki 637

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -380,12 +380,12 @@ public class WikiServiceImpl implements WikiService, Startable {
         movePage.setMovedMixin(session.create(MovedMixin.class));
         mix = movePage.getMovedMixin();
         mix.setTargetPage(movePage.getParentPage());
-        session.save();
       }
       mix.setTargetPage(destPage);      
       WikiImpl destWiki = (WikiImpl) destPage.getWiki();
       movePage.setParentPage(destPage);
       movePage.setMinorEdit(false);
+      session.save();
       
       //update LinkRegistry
       if (!newLocationParams.getType().equals(currentLocationParams.getType())) {


### PR DESCRIPTION
Problem analysis:
- Not saving session properly after moving page causes not able to get path of destination page
  Solution:
- Saving session before getting path of destination page
