### PR TITLE
Fix/4.0.x/wiki 638

### DIFF
--- a/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchForm.java
+++ b/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchForm.java
@@ -156,6 +156,15 @@ public class UIWikiAdvanceSearchForm extends UIForm {
   public void setItemsPerPage(int value) {
     itemPerPage = value;
   }
+  
+  /**
+   * Get number of items per page
+   * 
+   * @return the itemPerPage
+   */
+  public int getItemPerPage() {
+    return itemPerPage;
+  }
 
   public void gotoSearchPage(int pageIndex) throws Exception {
     pageIndex = (int) Math.min(pageIndex, getPageAvailable());

--- a/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchResult.java
+++ b/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchResult.java
@@ -58,8 +58,9 @@ public class UIWikiAdvanceSearchResult extends UIContainer {
   }
   
   public int getItemsPerPage() {
-    if (results == null) { return 0; }
-    return results.getPageSize();
+    UIWikiPortlet wikiPortlet = getAncestorOfType(UIWikiPortlet.class);
+    UIWikiAdvanceSearchForm advanceSearchForm = wikiPortlet.findFirstComponentOfType(UIWikiAdvanceSearchForm.class);
+    return advanceSearchForm.getItemPerPage();
   }
   
   public String getKeyword() {


### PR DESCRIPTION
 Analysis: In case of number of search result less than pagesize, pagesize Listbox always show that number instead of standard page sizes
 Solution: Show value 10, 20, 30.. correctly, not depends to search result
