### PR TITLE
WIKI-658: Lack of tooltip if mouse over the [Rename] button of "Move wik...

### DIFF
--- a/wiki-webapp/src/main/webapp/skin/less/Notifications/Style.less
+++ b/wiki-webapp/src/main/webapp/skin/less/Notifications/Style.less
@@ -29,15 +29,6 @@
 	color: @infoText;
 	padding: 7px 15px 7px 45px;
 	margin: 10px 0;
-	
-	a{
-		color: @linkColor;
-	}
-	& a:hover{
-		font-weight: bold;
-		text-decoration: none;
-	}
-	
 }
 
 


### PR DESCRIPTION
...i page" action's popup
