### PR TITLE
WIKI-606 rendering on some box macro

### DIFF
--- a/wiki-webapp/src/main/webapp/skin/less/wiki.less
+++ b/wiki-webapp/src/main/webapp/skin/less/wiki.less
@@ -491,3 +491,8 @@
 
 
 
+.macro-output, .uiWikiPagePreview, .uiWikiContentDisplay{
+	span.box{
+		display: block;
+	}
+}


### PR DESCRIPTION
Problem analysis:
- Macros tip, warning, info actually generate span element.
- In PLF 3.5 these items are not broken because span is set to "display: block"
Solution:
- Set "display: block" for span tag generated by macros tip, warning, info