### PR TITLE
WIKI-654: Display * character beside user fullname in warning message wh...

### DIFF
--- a/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiPageEditForm.java
+++ b/wiki-webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiPageEditForm.java
@@ -195,10 +195,9 @@ public class UIWikiPageEditForm extends UIWikiForm {
     StringBuilder usernameList = new StringBuilder();
     OrganizationService organizationService = (OrganizationService) PortalContainer.getComponent(OrganizationService.class);
     for (String user : users) {
-      usernameList.append("**");
       User userObject = organizationService.getUserHandler().findUserByName(user);
       usernameList.append(userObject.getFullName());
-      usernameList.append("**, ");
+      usernameList.append(", ");
     }
     
     // Remove 2 last chars


### PR DESCRIPTION
...en editing a page

Fix description: Remove *\* at the beginning and the end of user name in message
