### PR TITLE
WIKI-769 Wiki syntax error

### DIFF
--- a/wiki-webapp/src/main/webapp/skin/DefaultSkin/webui/UIWikiRichTextEditor/RichTextArea.css
+++ b/wiki-webapp/src/main/webapp/skin/DefaultSkin/webui/UIWikiRichTextEditor/RichTextArea.css
@@ -51,8 +51,8 @@ body.UIWikiPortletWysiwygCss { /*
   Overwrite no matter what list-style-position to outside position to avoid the Firefox issues with editing lists
   with inside list style. 
 */
-.UIWikiPortletWysiwygCss ul,.UIWikiPortletWysiwygCss ol {
-  list-style-position: outside !important;
+.UIWikiPortletWysiwygCss ul {
+  list-style-type: circle;
 }
 
 /*

--- a/wiki-webapp/src/main/webapp/skin/less/UIWikiPageContent/Style.less
+++ b/wiki-webapp/src/main/webapp/skin/less/UIWikiPageContent/Style.less
@@ -4,10 +4,13 @@
 	ul {
 		margin: 10px 18px;
 		padding: 0;
+		list-style-type: circle;
 	}
-	ul li {
-		list-style: disc outside none;
+	ul li{
+		list-style-position: inside;
+		list-style-type: inherit;
 	}
+	
 	ul li a {
 		text-decoration: none;
 	}
@@ -16,7 +19,7 @@
 		padding: 0;
 	}
 	ol li {
-		list-style: decimal outside none;
+		list-style-position	: inside;
 	}
 
 	hr {


### PR DESCRIPTION
Fix description:
- Fix the problem of display list style type when previewing and saving by using xwiki syntax of list
- Fix the problem of display list style type when using list syntax with style define by mandatory
- Fix the problem of display list style in RichTextArea.
