### PR TITLE
WIKI-780: Count attachment didn't update when attachment is removed

### DIFF
--- a/wiki-service/src/main/resources/conf/portal/configuration.xml
+++ b/wiki-service/src/main/resources/conf/portal/configuration.xml
@@ -287,6 +287,32 @@
         </object-param>
       </init-params>
     </component-plugin>
+    
+   <component-plugin>
+      <name>Update rendering cache when attachment is removed</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.services.jcr.impl.ext.action.AddActionsPlugin</type>
+      <description>Update rendering cache when attachment is removed</description>
+      <init-params>
+        <object-param>
+          <name>actions</name>
+          <object type="org.exoplatform.services.jcr.impl.ext.action.AddActionsPlugin$ActionsConfig">
+            <field  name="actions">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <object type="org.exoplatform.services.jcr.impl.ext.action.ActionConfiguration">
+                    <field  name="eventTypes"><string>removeNode</string></field>
+                    <field  name="nodeTypes"><string>wiki:attachment</string></field>
+                    <field  name="actionClassName"><string>org.exoplatform.wiki.service.jcrext.UpdateWikiPageAction</string></field>
+                  </object>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  
   </external-component-plugins>
   
   <external-component-plugins>


### PR DESCRIPTION
Fix description:
- Problem: Missing the configuration to update rendering cache when attachment is removed
- Fix : Add more conponent plugin in wiki service configuration.xml to update rendering cache in case attachment is removed.
