### PR TITLE
WIKI-519 Broken PageContentArea after unfolding a page from pagetree mac...

### DIFF
--- a/wiki-webapp/src/main/webapp/javascript/eXo/wiki/tree/UITreeExplorer.js
+++ b/wiki-webapp/src/main/webapp/javascript/eXo/wiki/tree/UITreeExplorer.js
@@ -147,6 +147,8 @@ UITreeExplorer.prototype.render = function(param, element, isFullRender) {
 	      me.renderTreeNodes(childBlock, data);
 	    }
 	  });
+
+	  eXo.wiki.WikiLayout.setHeightLayOut();
 	}
 };
 


### PR DESCRIPTION
...ro

Fix description: ReCalculate height of page area after first time unfolding page