### PR TITLE
WIKI-952: RepositoryException "Data too long for column 'NAME'" when add...

### DIFF
--- a/wiki-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
+++ b/wiki-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
@@ -216,6 +216,7 @@ UIWikiDeletePageConfirm.action.Cancel=#{word.cancel}
 SavePageAction.msg.warning-page-title-already-exist=The page title already exists. Please select another one.
 WikiPageNameValidator.msg.Invalid-char=The following characters are not allowed in the page title: {0}.
 WikiPageNameValidator.msg.EmptyTitle=The page title is required.
+WikiPageNameValidator.msg.TooLongTitle=The length of page title must be smaller than {0} characters.
 #############################################################################
 #							SaveTemplateAction   																						
 #############################################################################

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/commons/WikiConstants.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/commons/WikiConstants.java
@@ -29,4 +29,6 @@ public interface WikiConstants {
   public static final String IS_MARKUP          = "isMarkup";
 
   public static final String WITH               = "With";
+
+  public static final int MAX_LENGTH_TITLE      = 512;
 }

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
@@ -39,6 +39,7 @@ import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.UIFormTextAreaInput;
 import org.exoplatform.webui.form.input.UICheckBoxInput;
 import org.exoplatform.wiki.commons.Utils;
+import org.exoplatform.wiki.commons.WikiConstants;
 import org.exoplatform.wiki.mow.api.DraftPage;
 import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.mow.api.WikiNodeType;
@@ -121,6 +122,11 @@ public class SavePageActionComponent extends UIComponent {
         if(StringUtils.isEmpty(title)){
           event.getRequestContext().getUIApplication()
                   .addMessage(new ApplicationMessage("WikiPageNameValidator.msg.EmptyTitle", null, ApplicationMessage.WARNING));
+          Utils.redirect(Utils.getCurrentWikiPageParams(), WikiMode.EDITPAGE);
+          return;
+        } else if (title.length() > WikiConstants.MAX_LENGTH_TITLE) {
+          event.getRequestContext().getUIApplication()
+                  .addMessage(new ApplicationMessage("WikiPageNameValidator.msg.TooLongTitle", new Object[] {WikiConstants.MAX_LENGTH_TITLE} , ApplicationMessage.WARNING));
           Utils.redirect(Utils.getCurrentWikiPageParams(), WikiMode.EDITPAGE);
           return;
         }


### PR DESCRIPTION
...ing wiki page with long accent title

Problem analysis
- Page title must be fitted with NAME field which contains maximum 512 characters

Fix description
- Limit the length of page title at 512