### PR TITLE
WIKI-767: [IE8] When pointer is focusing on text field in Rich Text then...

### DIFF
--- a/wiki-webapp/src/main/webapp/javascript/eXo/wiki/UIWikiPageEditForm.js
+++ b/wiki-webapp/src/main/webapp/javascript/eXo/wiki/UIWikiPageEditForm.js
@@ -61,6 +61,10 @@ UIWikiPageEditForm.prototype.init = function(pageEditFormId, restURL, isRunAutoS
   var textAreaContainer = $(pageEditForm).find('div.uiWikiPageContentInputContainer')[0];
   if (!textAreaContainer) {
     textAreaContainer = $(pageEditForm).find('div.UIWikiRichTextEditor')[0];
+  } else {
+    setTimeout(function () {
+      $(textAreaContainer).find('textarea')[0].focus();
+    }, 100);
   }
   
   // Bind event for text area and title input
@@ -75,7 +79,6 @@ UIWikiPageEditForm.prototype.init = function(pageEditFormId, restURL, isRunAutoS
     if (textarea) {
     	$(textarea.contentWindow.document).bind('keyup', func);
     }
-//    textarea = $(textAreaContainer).find('iframe').bind('change',func);
   }
 };
 


### PR DESCRIPTION
... switch to source mode, text field is uneditable

Problem analysis:
- When the pointer is focusing on an invisible object in IE, it cannot be focused in other field.
- After loading rich text field, this field is focused. But in the source mode, I cannot see this behavior.

Fix description:
- Force forcusing on source field in Source mode
