### PR TITLE
WIKI-959: CLONE - [Unified search] Cannot search Event/Task with special...

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -93,8 +93,8 @@ public class Utils {
   
   public static final String WIKI_RESOUCE_BUNDLE_NAME = "locale.wiki.service.WikiService";
   
-  private static final String ILLEGAL_SEARCH_CHARACTERS= "!^()+{}[]:-\"";
-  
+  private static final String ILLEGAL_SEARCH_CHARACTERS= "\\!^()+{}[]:-\"";
+
   public static final String SPLIT_TEXT_OF_DRAFT_FOR_NEW_PAGE = "_A_A_";
   
   public static String escapeIllegalCharacterInQuery(String query) {


### PR DESCRIPTION
... characters

Causes: We missing character "\" when escape in query
Solutin: I had been included "\" character when escape keyword