### PR TITLE
WIKI-950: Anonymous cannot view image in public wiki page

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/mow/api/WikiNodeType.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/mow/api/WikiNodeType.java
@@ -79,6 +79,8 @@ public interface WikiNodeType {
   public static final String WIKI_PAGE_DESCRIPTION   = "wiki:pageDescription";
   
   public static final String WIKI_MIGRATING          = "wiki:migrating";
+  
+  public static final String WIKI_PERMISSION_MIGRATION = "wiki:updateAttachment";
 
   public static final String MIX_VERSIONABLE = "mix:versionable";
   public static final String JCR_FROZEN_NODE = "jcr:frozenNode";

--- a/wiki-service/src/main/java/org/exoplatform/wiki/mow/core/api/wiki/UpdateAttachmentMixin.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/mow/core/api/wiki/UpdateAttachmentMixin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2003-2013 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package org.exoplatform.wiki.mow.core.api.wiki;
+
+import org.chromattic.api.RelationshipType;
+import org.chromattic.api.annotations.MixinType;
+import org.chromattic.api.annotations.OneToOne;
+import org.exoplatform.wiki.mow.api.WikiNodeType;
+
+@MixinType(name = WikiNodeType.WIKI_PERMISSION_MIGRATION)
+public abstract class UpdateAttachmentMixin {
+
+  @OneToOne(type = RelationshipType.EMBEDDED)
+  public abstract PageImpl getEntity();
+  public abstract void setEntity(PageImpl page);
+}

--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -1367,6 +1367,7 @@ public class WikiServiceImpl implements WikiService, Startable {
       PageImpl p = (PageImpl) queue.poll();
       if (!p.getOverridePermission()) {
         p.setPermission(permMap);
+        p.setUpdateAttachmentMixin(null);
       }
       Iterator<PageImpl> iter = p.getChildPages().values().iterator();
       while (iter.hasNext()) {

--- a/wiki-service/src/main/resources/conf/portal/wiki-nodetypes.xml
+++ b/wiki-service/src/main/resources/conf/portal/wiki-nodetypes.xml
@@ -535,6 +535,10 @@
   
   <nodeType name="wiki:migrating" isMixin="true" hasOrderableChildNodes="false" primaryItemName="">
   </nodeType>
+
+  <nodeType name="wiki:updateAttachment" isMixin="true" hasOrderableChildNodes="false" primaryItemName="">
+  </nodeType>
+
   
 </nodeTypes>
   

--- a/wiki-service/src/test/java/org/exoplatform/wiki/mow/core/api/TestPageAttachment.java
+++ b/wiki-service/src/test/java/org/exoplatform/wiki/mow/core/api/TestPageAttachment.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 
 
 import org.chromattic.ext.ntdef.Resource;
+import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.wiki.mow.api.Model;
 import org.exoplatform.wiki.mow.api.WikiType;
 import org.exoplatform.wiki.mow.core.api.wiki.AttachmentImpl;
@@ -92,6 +93,8 @@ public class TestPageAttachment extends AbstractMOWTestcase {
 
     // Check if permission is correct
     expectedPermissions.put("demo", org.exoplatform.services.jcr.access.PermissionType.ALL);
+    expectedPermissions.put(IdentityConstants.ANY, new String[] {
+            org.exoplatform.services.jcr.access.PermissionType.READ});
     HashMap<String, String[]> altualPermissions = attachment1.getPermission();
     for (String key : altualPermissions.keySet()) {
       String[] expectPermission = expectedPermissions.get(key);

--- a/wiki-upgrade-plugins/src/main/resources/conf/portal/wiki-nodetypes.xml
+++ b/wiki-upgrade-plugins/src/main/resources/conf/portal/wiki-nodetypes.xml
@@ -535,6 +535,10 @@
   
   <nodeType name="wiki:migrating" isMixin="true" hasOrderableChildNodes="false" primaryItemName="">
   </nodeType>
+  
+  <nodeType name="wiki:updateAttachment" isMixin="true" hasOrderableChildNodes="false" primaryItemName="">
+  </nodeType>
+
 
 </nodeTypes>
   

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPermalinkForm.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPermalinkForm.java
@@ -17,6 +17,7 @@
 package org.exoplatform.wiki.webui;
 
 import java.net.URLEncoder;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
@@ -39,6 +40,7 @@ import org.exoplatform.webui.form.UIForm;
 import org.exoplatform.wiki.commons.Utils;
 import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.mow.api.WikiType;
+import org.exoplatform.wiki.mow.core.api.wiki.AttachmentImpl;
 import org.exoplatform.wiki.mow.core.api.wiki.PageImpl;
 import org.exoplatform.wiki.service.PermissionEntry;
 import org.exoplatform.wiki.service.PermissionType;
@@ -119,6 +121,14 @@ public class UIWikiPermalinkForm extends UIForm implements UIPopupComponent {
         permissions.remove(IdentityConstants.ANY);
         currentPage.setPermission(permissions);
         
+        // Remove any permission of all attachments when making a page restricted
+        Collection<AttachmentImpl> attachments = ((PageImpl) currentPage).getAttachmentsExcludeContentByRootPermisison();
+        for (AttachmentImpl attachment : attachments) {
+          HashMap<String, String[]> attachmentPermissions = attachment.getPermission();
+          attachmentPermissions.remove(IdentityConstants.ANY);
+          attachment.setPermission(attachmentPermissions);
+        }
+        
         UIWikiPortlet uiWikiPortlet = uiWikiPermalinkForm.getAncestorOfType(UIWikiPortlet.class);
         if (currentPage.hasPermission(PermissionType.VIEWPAGE)) {
           UIWikiPageInfoArea uiWikiPageInfoArea = uiWikiPortlet.findFirstComponentOfType(UIWikiPageInfoArea.class);
@@ -148,6 +158,16 @@ public class UIWikiPermalinkForm extends UIForm implements UIPopupComponent {
             org.exoplatform.services.jcr.access.PermissionType.REMOVE,
             org.exoplatform.services.jcr.access.PermissionType.SET_PROPERTY});
         currentPage.setPermission(permissions);
+        
+        // Add any permission of all attachments when making a page public
+        Collection<AttachmentImpl> attachments = ((PageImpl) currentPage).getAttachmentsExcludeContentByRootPermisison();
+        for (AttachmentImpl attachment : attachments) {
+          HashMap<String, String[]> attachmentPermissions = attachment.getPermission();
+          if (!attachmentPermissions.containsKey(IdentityConstants.ANY)) {
+            attachmentPermissions.put(IdentityConstants.ANY, new String[] { org.exoplatform.services.jcr.access.PermissionType.READ });
+            attachment.setPermission(attachmentPermissions);
+          }
+        }
         
         UIWikiPortlet uiWikiPortlet = uiWikiPermalinkForm.getAncestorOfType(UIWikiPortlet.class);
         UIWikiPageInfoArea uiWikiPageInfoArea = uiWikiPortlet.findFirstComponentOfType(UIWikiPageInfoArea.class);

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPortlet.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPortlet.java
@@ -148,7 +148,10 @@ public class UIWikiPortlet extends UIPortletApplication {
         super.processRender(app, context);
         return;
       } else {
-        ((PageImpl)page).migrateLegacyData();
+        if (WikiMode.VIEW.equals(this.getWikiMode())) {
+          ((PageImpl)page).migrateLegacyData();
+          ((PageImpl)page).migrateAttachmentPermission();
+        }
         if (mode.equals(WikiMode.PAGE_NOT_FOUND)) {
           changeMode(WikiMode.VIEW);
         }

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
@@ -44,6 +44,7 @@ import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.mow.api.WikiNodeType;
 import org.exoplatform.wiki.mow.core.api.wiki.AttachmentImpl;
 import org.exoplatform.wiki.mow.core.api.wiki.PageImpl;
+import org.exoplatform.wiki.mow.core.api.wiki.UpdateAttachmentMixin;
 import org.exoplatform.wiki.rendering.RenderingService;
 import org.exoplatform.wiki.resolver.TitleResolver;
 import org.exoplatform.wiki.service.WikiPageParams;
@@ -229,10 +230,11 @@ public class SavePageActionComponent extends UIComponent {
             addedPage.getContent().setText(markup);
             addedPage.setSyntax(syntaxId);
             ((PageImpl) addedPage).getAttachments().addAll(attachs);
+            UpdateAttachmentMixin updateAttachment = ((PageImpl) addedPage).createUpdateAttachmentMixin();
+            ((PageImpl) addedPage).setUpdateAttachmentMixin(updateAttachment);
             ((PageImpl) addedPage).checkin();
             ((PageImpl) addedPage).checkout();
             draftPage.remove();
-  
             // remove the draft for new page
             Page parentPage = addedPage.getParentPage();
             DraftPage contentDraftPage = findTheMatchDraft(title, parentPage);


### PR DESCRIPTION
Fix description
- Grant read permission to any for attachments
- Add new nodetype to migrate on the fly the attachments of old wiki.
- Remove any permission when restricting page