### PR TITLE
WIKI-1000: WARN Malformed url when saving a wiki page

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -664,7 +664,7 @@ public class WikiServiceImpl implements WikiService, Startable {
     }
     
     String url = page.getURL();
-    if (url != null) {
+    if (url != null && url.contains("://")) {
       try {
         URL oldURL = new URL(url);
         page.setURL(oldURL.getPath());


### PR DESCRIPTION
Problem analysis:
* In Platform 3.5, page's URL is a full URL. Since Platform 4.0.0, the parameter only stores the path component.
  It is no longer necessary to parse this as URL.

Fix description:
* Create URL object only if the page's URL value contains :// (which locates between the protocol and the host in a URL).