### PR TITLE
WIKI-1031 : Remove "Untitled" value in Title Input text

### DIFF
--- a/wiki-webapp/src/main/webapp/javascript/eXo/wiki/UIWikiSavePage.js
+++ b/wiki-webapp/src/main/webapp/javascript/eXo/wiki/UIWikiSavePage.js
@@ -24,7 +24,7 @@ function UIWikiSavePage() {
 
 UIWikiSavePage.prototype.confirm = function(uicomponentId, isNewMode, pageTitleInputId, untitled, titleMessage, addMessage, submitClass, submitLabel, cancelLabel, titleWarning, warningMsg, okLabel) {
   var pageTitleInput = document.getElementById(pageTitleInputId);
-  if (isNewMode == true && (pageTitleInput.value == untitled)) {
+  if (isNewMode == true && (pageTitleInput.value == untitled || pageTitleInput.value == "")) {
     eXo.wiki.UIConfirmBox.render(uicomponentId, titleMessage, addMessage, submitClass, submitLabel, cancelLabel);
     return false;
   } else if (!eXo.wiki.UIConfirmBox.validate(pageTitleInputId)) {

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/AddPageActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/AddPageActionComponent.java
@@ -18,14 +18,12 @@ package org.exoplatform.wiki.webui.control.action;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.webui.util.Util;
-import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.config.annotation.EventConfig;
 import org.exoplatform.webui.event.Event;
@@ -35,7 +33,6 @@ import org.exoplatform.webui.form.UIFormStringInput;
 import org.exoplatform.webui.form.UIFormTextAreaInput;
 import org.exoplatform.wiki.commons.Utils;
 import org.exoplatform.wiki.mow.api.DraftPage;
-import org.exoplatform.wiki.mow.api.Page;
 import org.exoplatform.wiki.service.WikiContext;
 import org.exoplatform.wiki.service.WikiPageParams;
 import org.exoplatform.wiki.service.WikiService;
@@ -91,15 +88,13 @@ public class AddPageActionComponent extends AbstractEventActionComponent {
  
       UIWikiPortlet wikiPortlet = event.getSource().getAncestorOfType(UIWikiPortlet.class);
       wikiPortlet.changeMode(WikiMode.ADDPAGE);
-      WebuiRequestContext context = WebuiRequestContext.getCurrentInstance();
-      ResourceBundle res = context.getApplicationResourceBundle();
       WikiPageParams pageParams = Utils.getCurrentWikiPageParams();
       String pageTitle = draftPage == null ? pageParams.getParameter(WikiContext.PAGETITLE) : draftPage.getTitle();
       UIWikiPageEditForm pageEditForm = wikiPortlet.findFirstComponentOfType(UIWikiPageEditForm.class);
       UIFormStringInput titleInput = pageEditForm.getChild(UIWikiPageTitleControlArea.class).getUIStringInput();
       UIFormTextAreaInput markupInput = pageEditForm.findComponentById(UIWikiPageEditForm.FIELD_CONTENT);
       UIFormStringInput commentInput = pageEditForm.findComponentById(UIWikiPageEditForm.FIELD_COMMENT);
-      titleInput.setValue(res.getString("UIWikiPageTitleControlArea.label.Untitled"));
+      titleInput.setValue("");
 
       titleInput.setEditable(true);
       markupInput.setValue(draftPage == null ? "" : draftPage.getContent().getText());

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/action/SavePageActionComponent.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
@@ -28,6 +29,7 @@ import org.exoplatform.services.jcr.datamodel.IllegalNameException;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.web.application.ApplicationMessage;
+import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.config.annotation.EventConfig;
 import org.exoplatform.webui.core.UIComponent;
@@ -119,6 +121,14 @@ public class SavePageActionComponent extends UIComponent {
         boolean isRenamedPage = false;
         boolean isContentChange = false;
   
+        if (wikiPortlet.getWikiMode() == WikiMode.ADDPAGE && 
+            (titleInput.getValue() == null || titleInput.getValue().isEmpty())){
+          // Add a new page with empty title, set title value to Untitled
+          WebuiRequestContext context = WebuiRequestContext.getCurrentInstance();
+          ResourceBundle res = context.getApplicationResourceBundle();
+          titleInput.setValue(res.getString("UIWikiPageTitleControlArea.label.Untitled"));
+        }
+        
         String title = titleInput.getValue().trim();
         if(StringUtils.isEmpty(title)){
           event.getRequestContext().getUIApplication()


### PR DESCRIPTION
Remove "Untitled" value in Title Input text area. 
Result: The tip text is showed as "Untitled" in gray color, and will be disappeared when clicking on.