### PR TITLE
PLF-8284 : changing the domainURL pattern in order to accept portal in the domain

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/rendering/impl/DefaultWikiModel.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/rendering/impl/DefaultWikiModel.java
@@ -37,7 +37,6 @@ import org.xwiki.context.ExecutionContext;
 import org.xwiki.rendering.listener.reference.ResourceReference;
 import org.xwiki.rendering.listener.reference.ResourceType;
 import org.xwiki.rendering.wiki.WikiModel;
-
 import javax.inject.Inject;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -56,7 +55,6 @@ public class DefaultWikiModel implements WikiModel {
    */
   @Inject
   private Execution execution;
-  
   /**
    * Used to get the build context for document
    */
@@ -117,7 +115,7 @@ public class DefaultWikiModel implements WikiModel {
       WikiContext wikiMarkupContext = markupContextManager.getMarkupContext(imageName, resourceType);
       String portalContainerName = PortalContainer.getCurrentPortalContainerName();
       String portalURL = wikiMarkupContext.getPortalURL();
-      String domainURL = portalURL.substring(0, portalURL.indexOf("/"+portalContainerName));
+      String domainURL = portalURL.substring(0, portalURL.lastIndexOf("/"+portalContainerName));
       sb.append(domainURL);
       WikiContext context = getWikiContext();
       wikiService.addPageLink(new WikiPageParams(context.getType(), context.getOwner(), context.getPageName()),


### PR DESCRIPTION
This change on the domainURL may accept the use of a domain containing "**portal**". By default, it uses the format protocole://domainURL/. 
Using `domainURL = portalURL.substring(0, portalURL.IndexOf("/"+portalContainerName));` causes a problem with a domain name containing portal which will be used as for portalContainerName. For that we find the URL of images (http://portal/rest/...)
`portalURL.substring(0, portalURL.lastIndexOf("/"+portalContainerName));`  help to accept the domain names which contain **portal** (example: portal.exo.lan)