### PR TITLE
WIKI-1462 : escape wiki page content used in edit mode to prevent XSS issues

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/service/WikiRestService.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/service/WikiRestService.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.wiki.service;
 
+import javax.servlet.ServletContext;
 import javax.ws.rs.core.Response;
 
 /**
@@ -36,7 +37,8 @@ public interface WikiRestService {
      *
      * @LevelAPI Experimental
      */
-  Response getWikiPageContent(String sessionKey,
+  Response getWikiPageContent(ServletContext servletContext,
+                              String sessionKey,
                               String wikiContextKey,
                               boolean isMarkup,
                               String data);


### PR DESCRIPTION

In WYSIWYG edit mode, the wiki page content is retrieved from a REST endpoint and interpreted as is by the XWiki editor.
This makes it vulnerable to XSS issues.

This fix sanitize the wiki page content before sending it to the XWiki editor to make sure no XSS issue can be exploited.