### PR TITLE
WIKI-1400: Make sure that When a wiki page is made Public it can be editable or not by anyone.

### DIFF
--- a/wiki-webui/src/main/java/org/exoplatform/wiki/commons/Utils.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/commons/Utils.java
@@ -166,7 +166,7 @@ public class Utils {
   public static boolean isPagePublic(Page page) throws Exception {
     WikiService wikiService = (WikiService) PortalContainer.getComponent(WikiService.class);
     return (page != null)
-        && wikiService.hasPermissionOnPage(page, PermissionType.EDITPAGE, new Identity(IdentityConstants.ANONIM));
+        && wikiService.hasPermissionOnPage(page, PermissionType.VIEWPAGE, new Identity(IdentityConstants.ANONIM));
   }
 
   public static boolean isCurrentPagePublic() throws Exception {

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPermalinkForm.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiPermalinkForm.java
@@ -154,8 +154,8 @@ public class UIWikiPermalinkForm extends UIForm implements UIPopupComponent {
         List<PermissionEntry> permissions = currentPage.getPermissions();
         permissions.add(new PermissionEntry(IdentityConstants.ANY, "", IDType.MEMBERSHIP, new Permission[]{
                 new Permission(PermissionType.VIEWPAGE, true),
-                new Permission(PermissionType.EDITPAGE, true),
-                new Permission(PermissionType.ADMINPAGE, true)
+                new Permission(PermissionType.EDITPAGE, false),
+                new Permission(PermissionType.ADMINPAGE, false)
         }));
         currentPage.setPermissions(permissions);
 


### PR DESCRIPTION
When a wiki page is made "Public", it becomes editable by "anyone", and when trying to edit its permissions by making it not editable by "anyone", it automatically switches to "Restricted".
By this fix i make sure that a wiki page can be "Public" and at the same time not editable/editable by "anyone" by choice.