### PR TITLE
WIKI-1472 : Fix CSRF check for space switcher (#208)

### DIFF
--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchForm.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchForm.java
@@ -47,7 +47,7 @@ import java.util.Collections;
   template = "app:/templates/wiki/webui/UIWikiAdvanceSearchForm.gtmpl",
   events = {
       @EventConfig(listeners = UIWikiAdvanceSearchForm.SearchActionListener.class),
-      @EventConfig(listeners = UIWikiAdvanceSearchForm.SwitchSpaceActionListener.class)
+      @EventConfig(listeners = UIWikiAdvanceSearchForm.SwitchSpaceActionListener.class, csrfCheck = false)
     }
 )
 

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiBreadCrumb.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/UIWikiBreadCrumb.java
@@ -49,7 +49,7 @@ import java.util.List;
 @ComponentConfig(
   lifecycle = Lifecycle.class,
   template = "app:/templates/wiki/webui/UIWikiBreadCrumb.gtmpl",
-  events = {@EventConfig(listeners = UIWikiBreadCrumb.SwitchSpaceActionListener.class)}
+  events = {@EventConfig(listeners = UIWikiBreadCrumb.SwitchSpaceActionListener.class, csrfCheck = false)}
 )
 public class UIWikiBreadCrumb extends UIContainer {
 

--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/popup/UIWikiMovePageForm.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/popup/UIWikiMovePageForm.java
@@ -67,7 +67,7 @@ import org.exoplatform.wiki.webui.tree.UITreeExplorer;
   events = {
     @EventConfig(listeners = UIWikiMovePageForm.CloseActionListener.class),
     @EventConfig(listeners = UIWikiMovePageForm.MoveActionListener.class),
-    @EventConfig(listeners = UIWikiMovePageForm.SwitchSpaceActionListener.class),
+    @EventConfig(listeners = UIWikiMovePageForm.SwitchSpaceActionListener.class, csrfCheck = false),
     @EventConfig(listeners = UIWikiMovePageForm.RenameActionListener.class)
   }
 )


### PR DESCRIPTION
CSRF check was active for wiki space switcher which caused blank pages when we try to switch from space to space for moving wiki pages or just opening another wiki space.
The fix ignores the CSRF check since there is no data to post on server.