### PR TITLE
MAINT-27018 : The image alignement in the Ckeditor is wrong (#248)

### DIFF
--- a/wiki-webapp/src/main/webapp/skin/DefaultSkin/webui/UIWikiRichTextEditor/Stylesheet.css
+++ b/wiki-webapp/src/main/webapp/skin/DefaultSkin/webui/UIWikiRichTextEditor/Stylesheet.css
@@ -3,8 +3,6 @@
   background-color: #FFFFFF;
   border: 1px solid var(--ck-color-base-border);
   border-radius: var(--ck-border-radius);
-  display: flex;
-  flex-flow: column nowrap;
   margin-left: 1px;
   margin-right: 1px;
 }


### PR DESCRIPTION
* MAINT-27018 : The image alignement in the Ckeditor is wrong
* MAINT-27018 : Remove unnecessary CSS rule
Co-authored-by: Ali Hamdi <ahamdi@exoplatform.com>

(cherry picked from commit 1b61bef5df1acc066fd5e4f2e6613ea71fd178d7)