### PR TITLE
MAINT-26874: Fix space wiki page url on activity stream generated activity

### DIFF
--- a/wiki-webui/src/main/java/org/exoplatform/wiki/commons/Utils.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/commons/Utils.java
@@ -210,7 +210,7 @@ public class Utils {
         }
       }
     }
-    return "wiki";
+    return "WikiPortlet";
   }
 
   public static Page getCurrentNewDraftWikiPage() throws Exception {


### PR DESCRIPTION
Backport [commit](https://github.com/exodev/wiki/commit/75c7c47be4bad5106fcbc5f851b4c831903e5397)