### PR TITLE
MAINT-25355 : refresh UIExtensions before executing process Action

### DIFF
--- a/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/UIWikiExtensionContainer.java
+++ b/wiki-webui/src/main/java/org/exoplatform/wiki/webui/control/UIWikiExtensionContainer.java
@@ -37,6 +37,20 @@ public abstract class UIWikiExtensionContainer extends UIExtensionContainer {
 
   @Override
   public void processRender(WebuiRequestContext context) throws Exception {
+    refreshUIExtensions(context);
+  }
+
+  @Override
+  public void processAction(WebuiRequestContext context) throws Exception {
+    super.processAction(context);
+  }
+
+  @Override
+  public void processDecode(WebuiRequestContext context) throws Exception {
+    refreshUIExtensions(context);
+  }
+
+  private void refreshUIExtensions(WebuiRequestContext context) {
     try {
       UIWikiPortlet wikiPortlet = getAncestorOfType(UIWikiPortlet.class);
       HashMap<String, Object> extContext = wikiPortlet.getUIExtContext();
@@ -44,14 +58,14 @@ public abstract class UIWikiExtensionContainer extends UIExtensionContainer {
         UIExtensionManager manager = getApplicationComponent(UIExtensionManager.class);
         List<UIExtension> extensions = manager.getUIExtensions(getExtensionType());
         extensionSize = 0;
-        
+
         // Add new children
         if (extensions != null && extensions.size() > 0) {
           // Remove old extension
           for (UIExtension extension : extensions) {
-             removeChild(extension.getComponent());
+            removeChild(extension.getComponent());
           }
-          
+
           // Add new extension
           for (UIExtension extension : extensions) {
             UIComponent uicomponent = manager.addUIExtension(extension, extContext, this);


### PR DESCRIPTION


When opening a page to Edit and then opening a parent page to view, the update wiki page operation fails.
The the UI extensions used to save the page will be updated by the view of parent page and won't be rendered, thus when executing the Save action, we will get a NPE as the Save action of the subcomponent will be missing.
The fix refreshes the UIExtensions attached to each UIComponent when an action is fired to make sure we have all sub components available/updated with their actions.

(cherry picked from commit ba26e8e93d010a1fa5957e79bd0f069819a56622)