### PR TITLE
Remove exo.core.component.jdbc dependency

### DIFF
--- a/wiki-service/pom.xml
+++ b/wiki-service/pom.xml
@@ -193,11 +193,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.core</groupId>
-      <artifactId>exo.core.component.organization.jdbc</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.suigeneris</groupId>
       <artifactId>jrcs.rcs</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
When removing xstream dependency, we completly remove module exo.core.component.jdbc which was deprecated
This commit remove the dependency on this module