### PR TITLE
backport-41251: fix unreadable links on notes notification container

### DIFF
--- a/wiki-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
+++ b/wiki-webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
@@ -532,5 +532,6 @@ resource.user.placeholder=alias
 #############################################################################
 #SpaceApplications
 #############################################################################
-SpaceSettings.application.wiki.title=Wiki
+SpaceSettings.application.wiki.title=Notes
 SpaceSettings.application.wiki.description=Wiki Portlet
+

--- a/wiki-webapp/src/main/webapp/skin/less/wiki/UIWikiPageEditForm/Style.less
+++ b/wiki-webapp/src/main/webapp/skin/less/wiki/UIWikiPageEditForm/Style.less
@@ -130,5 +130,7 @@
 			height: 28px;
 		}
 	}
-
+	.uiWikiNotificationContainer a:not(.btn) {
+		color: @primaryColor;
+	}
 }


### PR DESCRIPTION
cherry-picked from [Commit](https://github.com/exoplatform/wiki/commit/3f7ebff03630a249c82437d91f8b455d1577c21d)