### PR TITLE
Task-43618 : Suspend wiki attachments display when DLP feature is disabled

### DIFF
--- a/wiki-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/wiki-service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -15,6 +15,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.api.notification.plugin.NotificationPluginUtils;
+import org.exoplatform.commons.api.settings.ExoFeatureService;
+import org.exoplatform.commons.dlp.processor.DlpOperationProcessor;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -592,7 +595,12 @@ public class Utils {
     cssClass.append(((String)mimeType).replaceAll("/|\\.", ""));
     return cssClass.toString();
   }
-  
+
+  public static boolean isDlpFeatureEnabled() {
+    ExoFeatureService featureService = CommonsUtils.getService(ExoFeatureService.class);
+    return featureService.isActiveFeature(DlpOperationProcessor.DLP_FEATURE);
+  }
+
   /**
    * gets rest context name
    * @return rest context name

--- a/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiBottomArea.gtmpl
+++ b/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiBottomArea.gtmpl
@@ -1,7 +1,7 @@
 <%
   import org.exoplatform.wiki.utils.Utils;
 
-  boolean isDlpFeatureEnabled = org.exoplatform.wiki.utils.Utils.isDlpFeatureEnabled();
+  boolean isDlpFeatureEnabled = Utils.isDlpFeatureEnabled();
 %>
 <div class="uiWikiBottomArea" id="$uicomponent.id">
 <%

--- a/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiBottomArea.gtmpl
+++ b/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiBottomArea.gtmpl
@@ -1,10 +1,17 @@
+<%
+  import org.exoplatform.wiki.utils.Utils;
+
+  boolean isDlpFeatureEnabled = org.exoplatform.wiki.utils.Utils.isDlpFeatureEnabled();
+%>
 <div class="uiWikiBottomArea" id="$uicomponent.id">
 <%
-  List children = uicomponent.getChildren() ;
-  for(component in children) {
-    if(component.isRendered()){
-      uicomponent.renderChild(component.getClass()) ;
-    }
+  if(!isDlpFeatureEnabled) {
+   List children = uicomponent.getChildren() ;
+   for(component in children) {
+     if(component.isRendered()){
+       uicomponent.renderChild(component.getClass()) ;
+     }
+   }
   }
 %>
 </div>

--- a/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiPageInfoArea.gtmpl
+++ b/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiPageInfoArea.gtmpl
@@ -6,6 +6,7 @@
   import org.exoplatform.wiki.commons.Utils;
   import org.exoplatform.container.ExoContainerContext;
   import org.apache.commons.lang.StringEscapeUtils;
+  import org.exoplatform.wiki.utils.Utils;
 
   Locale currentLocale = Util.getPortalRequestContext().getLocale();
   DateFormat df = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT, currentLocale);
@@ -35,6 +36,8 @@
   String publicLinkTitle = _ctx.appRes("UIWikiPageInfoArea.label.public-link");
 
   boolean isCurrentPagePublic = uicomponent.isPagePublic(currentWikiPage);
+
+  boolean isDlpFeatureEnabled = org.exoplatform.wiki.utils.Utils.isDlpFeatureEnabled();
 %>
 <div id="$uicomponent.id" class="uiWikiPageInfoArea">
   <div class="txtFeed">
@@ -53,7 +56,9 @@
     <% } else { %>
       <a style="white-space:nowrap" rel="tooltip" data-placement="bottom" title="$restrictLinkTitle" href="javascript:void(0);" onclick="<%=uicomponent.event(uicomponent.PERMALINK_ACTION);%>"><i class='uiIconLockMini uiIconLightGray'></i>&nbsp;<%=_ctx.appRes("UIWikiPageInfoArea.label.Restrict")%></a>
     <% }%>
-    &nbsp;-&nbsp;	  
-    <a href="javascript:void(0);" onclick="$togglelink"><i class='uiIconAttach'></i>&nbsp;<%= totalAttachmentsLabel %></a>  
-	</div>
+    &nbsp;-&nbsp;
+    <% if (!isDlpFeatureEnabled) { %>
+    <a href="javascript:void(0);" onclick="$togglelink"><i class='uiIconAttach'></i>&nbsp;<%= totalAttachmentsLabel %></a>
+    <% }%>
+    </div>
 </div>

--- a/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiPageInfoArea.gtmpl
+++ b/wiki-webapp/src/main/webapp/templates/wiki/webui/UIWikiPageInfoArea.gtmpl
@@ -6,7 +6,6 @@
   import org.exoplatform.wiki.commons.Utils;
   import org.exoplatform.container.ExoContainerContext;
   import org.apache.commons.lang.StringEscapeUtils;
-  import org.exoplatform.wiki.utils.Utils;
 
   Locale currentLocale = Util.getPortalRequestContext().getLocale();
   DateFormat df = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT, currentLocale);
@@ -57,8 +56,8 @@
       <a style="white-space:nowrap" rel="tooltip" data-placement="bottom" title="$restrictLinkTitle" href="javascript:void(0);" onclick="<%=uicomponent.event(uicomponent.PERMALINK_ACTION);%>"><i class='uiIconLockMini uiIconLightGray'></i>&nbsp;<%=_ctx.appRes("UIWikiPageInfoArea.label.Restrict")%></a>
     <% }%>
     &nbsp;-&nbsp;
-    <% if (!isDlpFeatureEnabled) { %>
-    <a href="javascript:void(0);" onclick="$togglelink"><i class='uiIconAttach'></i>&nbsp;<%= totalAttachmentsLabel %></a>
+    <% if(!isDlpFeatureEnabled) { %>
+      <a href="javascript:void(0);" onclick="$togglelink"><i class='uiIconAttach'></i>&nbsp;<%= totalAttachmentsLabel %></a>
     <% }%>
     </div>
 </div>


### PR DESCRIPTION
- Before this fix, Wiki attachments are displayed and not moved to DLP feature when they contain keywords.
- This fix will ensure that the wiki attachments container and wiki attachments icon are hidden when DLP feature status is disabled.